### PR TITLE
修复 bibtex 展示问题与 head description 更新

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="Put your description here.">
+    <meta name="description" content="A panorama video generation pipeline based on the given prompts and motion conditions.">
 
     <title>360DVD: Controllable Panorama Video Generation with 360-Degree Video Diffusion Model</title>
     <link rel="icon" href="./static/images/page.svg">

--- a/index.html
+++ b/index.html
@@ -412,12 +412,12 @@
     <section class="bibtex">
         <h2 class="title">BibTeX</h2>
         <pre><code>
-        @article{wang2024360dvd,
-            title={360DVD: Controllable Panorama Video Generation with 360-Degree Video Diffusion Model},
-            author={Qian Wang and Weiqi Li and Chong Mou and Xinhua Cheng and Jian Zhang},
-            journal={arXiv preprint arXiv:2401.06578},
-            year={2024}
-        }
+@article{wang2024360dvd,
+    title={360DVD: Controllable Panorama Video Generation with 360-Degree Video Diffusion Model},
+    author={Qian Wang and Weiqi Li and Chong Mou and Xinhua Cheng and Jian Zhang},
+    journal={arXiv preprint arXiv:2401.06578},
+    year={2024}
+}
         </code></pre>
     </section>
 

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -200,7 +200,14 @@ section > p {
     font-size: 1.75rem;
 }
 
+.bibtex > pre > code {
+    overflow-x: auto;
+    display: block;
+}
+
 pre {
+    display: flex;
+    justify-content: center;
     padding: 1.25rem 1.5rem;
     background-color: #f5f5f5;
     color: #4a4a4a;


### PR DESCRIPTION
补充了 head 中的 description。

html  中 `code` 标签里的空格会被按原样展示，因此内容编写时需要去掉最前面的空格缩进。

修复了小屏幕下，会超出显示范围，修改为可以横向滑动

修复了大屏幕下未正确居中的问题

原有样式：

https://github.com/Akaneqwq/360DVD/assets/43703639/3ad397d5-a535-4c5f-8a60-acd0349ee65b

修改后：

https://github.com/Akaneqwq/360DVD/assets/43703639/de41a15c-1d54-41f8-8172-3feee56951bc
